### PR TITLE
v0.7.0: Adopt `Uint8Array<ArrayBuffer>` for Deno v2.5+

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
 version: 2
 updates:
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "monthly"
+      interval: monthly
+    groups:
+      official:
+        patterns:
+        - "actions/*"

--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         deno-version:
-        - v2.2
         - v2.3
         - v2.4
         - v2.5
@@ -35,9 +34,6 @@ jobs:
       with:
         path: ~/.cache/deno
         key: denodir/${{ matrix.deno-version }}-${{ hashFiles('deno.lock') }}
-
-    - name: Possibly reset lockfile
-      run: deno install || rm deno.lock
 
     - name: Check index.ts
       run: deno check ./lib/index.ts
@@ -81,9 +77,15 @@ jobs:
       id-token: write
 
     steps:
+    - uses: actions/checkout@v6
+
     - uses: denoland/setup-deno@v2
 
-    - uses: actions/checkout@v6
+    - name: Cache Deno deps
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/deno
+        key: denodir-${{ hashFiles('deno.lock') }}
 
     - name: Publish now
       run: deno publish

--- a/deno.lock
+++ b/deno.lock
@@ -3,12 +3,12 @@
   "specifiers": {
     "jsr:@deno-library/progress@^1.5.1": "1.5.1",
     "jsr:@std/assert@^1.0.16": "1.0.16",
-    "jsr:@std/cli@^1.0.24": "1.0.24",
+    "jsr:@std/cli@^1.0.25": "1.0.25",
     "jsr:@std/crypto@^1.0.5": "1.0.5",
     "jsr:@std/fmt@1.0.3": "1.0.3",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/io@0.225.0": "0.225.0",
-    "jsr:@std/path@^1.1.3": "1.1.3"
+    "jsr:@std/path@^1.1.4": "1.1.4"
   },
   "jsr": {
     "@deno-library/progress@1.5.1": {
@@ -24,8 +24,8 @@
         "jsr:@std/internal"
       ]
     },
-    "@std/cli@1.0.24": {
-      "integrity": "b655a5beb26aa94f98add6bc8889f5fb9bc3ee2cc3fc954e151201f4c4200a5e",
+    "@std/cli@1.0.25": {
+      "integrity": "1f85051b370c97a7a9dfc6ba626e7ed57a91bea8c081597276d1e78d929d8c91",
       "dependencies": [
         "jsr:@std/internal"
       ]
@@ -42,8 +42,8 @@
     "@std/io@0.225.0": {
       "integrity": "c1db7c5e5a231629b32d64b9a53139445b2ca640d828c26bf23e1c55f8c079b3"
     },
-    "@std/path@1.1.3": {
-      "integrity": "b015962d82a5e6daea980c32b82d2c40142149639968549c649031a230b1afb3",
+    "@std/path@1.1.4": {
+      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
         "jsr:@std/internal"
       ]
@@ -54,7 +54,7 @@
       "examples": {
         "dependencies": [
           "jsr:@deno-library/progress@^1.5.1",
-          "jsr:@std/cli@^1.0.24"
+          "jsr:@std/cli@^1.0.25"
         ]
       },
       "lib": {
@@ -65,7 +65,7 @@
       "test": {
         "dependencies": [
           "jsr:@std/assert@^1.0.16",
-          "jsr:@std/path@^1.1.3"
+          "jsr:@std/path@^1.1.4"
         ]
       }
     }

--- a/examples/deno.json
+++ b/examples/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
     "@deno-library/progress": "jsr:@deno-library/progress@^1.5.1",
-    "@std/cli": "jsr:@std/cli@^1.0.24"
+    "@std/cli": "jsr:@std/cli@^1.0.25"
   }
 }

--- a/lib/deno.json
+++ b/lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudydeno/docker-registry-client",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "MPL",
   "imports": {
     "@std/crypto": "jsr:@std/crypto@^1.0.5"

--- a/lib/docker-json-client.ts
+++ b/lib/docker-json-client.ts
@@ -149,6 +149,7 @@ export class DockerResponse extends Response implements DockerResponseInterface 
 
     dockerStream(): ReadableStream<ByteArray> {
         if (!this.body) throw new Error(`No body to stream`);
-        return this.body;
+        // TODO: Backwards compat for Deno 2.4 and earlier, remove cast eventually
+        return this.body as ReadableStream<ByteArray>;
     }
 }

--- a/lib/docker-json-client.ts
+++ b/lib/docker-json-client.ts
@@ -4,7 +4,7 @@
  */
 
 import { HttpError } from "./errors.ts";
-import type { DockerResponse as DockerResponseInterface } from "./types.ts";
+import type { ByteArray, DockerResponse as DockerResponseInterface } from "./types.ts";
 
 // --- API
 
@@ -82,9 +82,9 @@ export class DockerJsonClient {
 
 export class DockerResponse extends Response implements DockerResponseInterface {
     // Cache the body once we decode it once.
-    decodedBody?: Uint8Array;
+    decodedBody?: ByteArray;
 
-    async dockerBody(): Promise<Uint8Array> {
+    async dockerBody(): Promise<ByteArray> {
         this.decodedBody ??= new Uint8Array(await this.arrayBuffer());
         return this.decodedBody;
     }
@@ -147,7 +147,7 @@ export class DockerResponse extends Response implements DockerResponseInterface 
         }
     }
 
-    dockerStream(): ReadableStream<Uint8Array> {
+    dockerStream(): ReadableStream<ByteArray> {
         if (!this.body) throw new Error(`No body to stream`);
         return this.body;
     }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,5 @@
+/** An alias for Uint8Array now that Typescript 5.7 */
+export type ByteArray = Uint8Array<ArrayBuffer>;
 
 export interface RegistryIndex {
   name: string;
@@ -144,9 +146,9 @@ export type AuthInfo =
 
 
 export interface DockerResponse extends Response {
-  dockerBody(): Promise<Uint8Array>;
+  dockerBody(): Promise<ByteArray>;
   dockerJson(): Promise<unknown>;
-  dockerStream(): ReadableStream<Uint8Array>;
+  dockerStream(): ReadableStream<ByteArray>;
 
   dockerErrors(): Promise<Array<RegistryError>>;
   dockerThrowable(baseMsg: string): Promise<Error>;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,5 @@
-/** An alias for Uint8Array now that Typescript 5.7 */
-export type ByteArray = Uint8Array<ArrayBuffer>;
+/** An alias for Uint8Array<ArrayBuffer> for Typescript 5.7 */
+export type ByteArray = ReturnType<Uint8Array["slice"]>;
 
 export interface RegistryIndex {
   name: string;

--- a/test/deno.json
+++ b/test/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
     "@std/assert": "jsr:@std/assert@^1.0.16",
-    "@std/path": "jsr:@std/path@^1.1.3"
+    "@std/path": "jsr:@std/path@^1.1.4"
   }
 }


### PR DESCRIPTION
This change is a bit rough, but seems like the way forward with TS 5.9.
Becomes relevant when using the returned buffers with APIs that explicitly require `Uint8Array<ArrayBuffer>`.

Also defining a type alias to make the switch a little less verbose.

See Also:
https://github.com/denoland/deno/issues/30684#issuecomment-3276056663